### PR TITLE
Add automate testing framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+dist: trusty
+
+language: node_js
+node_js:
+  - "node"
+  - "8"
+
+before_install:
+  - npm i -g npm@5.6.0
+
+install:
+  - npm install -g coffeelint
+
+script:
+  - coffeelint scripts

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Hubot Natural
 
+[![Build Status](https://travis-ci.org/RocketChat/hubot-natural.svg?branch=master)](https://travis-ci.org/RocketChat/hubot-natural)
+
 ## Natural Language ChatBot
 
 Hubot is one of the most famous bot creating framework on the web, that's because github made it easy to create. If you can define your commands in a RegExp param, basically you can do anything with Hubot. That's a great contribution to ChatOps culture.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "js-yaml": "^3.2.5",
     "natural": "^0.5.0"
   },
+  "devDependencies": {
+    "coffeelint": "^2.0.7"
+  },
   "engines": {
     "node": "0.10.x"
   }


### PR DESCRIPTION
Travis.CI was added to, initially, automate testing. It can further be used to perform CI/CD.
Travis.CI was configured to run Cofffeelint (with default settings) inside folder `scripts` and the Travis.CI badge `build` was added. Coffeelint was also added as a development dependency.

ATTENTION: Travis.CI integration must be added to the official repository in order to make the automated tests and the `build` badge work.