### PR TITLE
Add recursive strategy when reading the training corpus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ LABEL mantainer "Diego Dorgam <diego.dorgam@rocket.chat>"
 
 ENV HUBOT_LANG='en'                                                  \
     HUBOT_CORPUS='training_data/corpus.yml'                          \
+    HUBOT_RECURSIVE_TRAINING=false                                   \
     HUBOT_ADAPTER=rocketchat                                         \
     HUBOT_OWNER=RocketChat                                           \
     HUBOT_NAME=HubotNatural                                          \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - HUBOT_DESCRIPTION='Hubot natural language processing'
       - HUBOT_LOG_LEVEL=debug
       - HUBOT_CORPUS=training_data/corpus.yml
+      - HUBOT_RECURSIVE_TRAINING=false
       - HUBOT_LANG=pt
       - RESPOND_TO_DM=true
       - RESPOND_TO_LIVECHAT=true


### PR DESCRIPTION
This recursive strategy will:
- Fix error when trying to put folders inside the training data folder;
- Make it possible to divide the training data into many folders.