### PR TITLE
Small bugfix on createMatch function

### DIFF
--- a/scripts/bot/index.coffee
+++ b/scripts/bot/index.coffee
@@ -37,7 +37,7 @@ sendWithNaturalDelay = (msgs, elapsed = 0) ->
   , delay
 
 createMatch = (text) ->
-  return res.message.text.match new RegExp('\\b' + text + '\\b', 'i')
+  return text.match new RegExp('\\b' + text + '\\b', 'i')
 
 module.exports = (_config, robot) ->
   global.config = _config


### PR DESCRIPTION
createMatch function receives a text already, but it was dealing as it was a res object.

This closes #42