### PR TITLE
Refactor asynchronous calls in the code to use async/await

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,11 +34,11 @@ services:
 
   # this container's job is just run the command to initialize the replica set.
   # it will run the command and remove himself (it will not stay running)
-  # mongo-init-replica:
-  #   image: mongo:3.2
-  #   command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
-  #   depends_on:
-  #     - mongo
+  mongo-init-replica:
+    image: mongo:3.2
+    command: 'mongo mongo/rocketchat --eval "rs.initiate({ _id: ''rs0'', members: [ { _id: 0, host: ''localhost:27017'' } ]})"'
+    depends_on:
+      - mongo
 
   hubot-natural:
     image: diegodorgam/hubot-natural:latest

--- a/scripts/actions/respond.js
+++ b/scripts/actions/respond.js
@@ -8,7 +8,7 @@
 
 const { msgVariables, stringElseRandomKey } = require('../lib/common');
 
-const livechat_department = (process.env.LIVECHAT_DEPARTMENT_ID || null );
+const livechat_department = (process.env.LIVECHAT_DEPARTMENT_ID || null);
 
 class Respond {
   constructor(interaction) {
@@ -40,29 +40,33 @@ class Respond {
     }
   }
 
-
   livechatTransfer(msg, delay, lc_dept, offline_message, type) {
     if (delay == null) { delay = 3000; }
-    return setTimeout((() => msg.robot.adapter.callMethod('livechat:transfer', {
-                      roomId: msg.envelope.room,
-                      departmentId: lc_dept
-                    }
-                    ).then(function(result) {
-                      if (result === true) {
-                        return console.log('livechatTransfer executed!');
-                      } else {
-                        console.log('livechatTransfer NOT executed!');
-                        switch (type) {
-                          case 'block':
-                            var messages = offline_message.map(line => msgVariables(line, msg));
-                            return msg.sendWithNaturalDelay(messages);
-                          case 'random':
-                            var message = stringElseRandomKey(offline_message);
-                            message = msgVariables(message, msg);
-                            return msg.sendWithNaturalDelay(message);
-                        }
-                      }
-                }) ), delay);
+    async function getResult() {
+      try {
+        let result = await msg.robot.adapter.callMethod('livechat:transfer', {
+          roomId: msg.envelope.room,
+          department: lc_dept
+        });
+      } catch (err) {
+        console.log(err);
+      }
+      if (result === true) {
+        return console.log('livechatTransfer executed!');
+      } else {
+        switch (type) {
+          case 'block':
+            var messages = offline_message.map(line => msgVariables(line, msg));
+            return msg.sendWithNaturalDelay(messages);
+          case 'random':
+            var messages = offline_message.map(line => msgVariables(line, msg));
+            var message = stringElseRandomKey(offline_message);
+            message = msgVariables(message, msg);
+            return msg.sendWithNaturalDelay(message);
+        }
+      }
+    }
+    return setTimeout(getResult(), delay);
   }
 }
 

--- a/scripts/lib/security.js
+++ b/scripts/lib/security.js
@@ -1,17 +1,20 @@
 const security = {};
 
-security.getUserRoles = function(robot) {
+security.getUserRoles = async function(robot) {
   const usersAndRoles = {};
-  robot.adapter.callMethod('getUserRoles').then(function(users) {
+  try {
+    const users = await robot.adapter.callMethod('getUserRoles');
     users.forEach(function(user) {
       user.roles.forEach(function(role) {
         if (typeof usersAndRoles[role] === 'undefined') {
           usersAndRoles[role] = [];
         }
         usersAndRoles[role].push(user.username);
-      });
-    });
-  });
+      })
+    })
+  }catch(err){
+    console.log(err);
+  }
   return usersAndRoles;
 };
 


### PR DESCRIPTION
[WIP]

This PR is about issue #47 .

- [x] refactor security.js
- [x] refacotr respond.js

To run hubot in docker I needed to uncomment mongo-init-replica in `docker-compose.yml`, tell me if it's wrong to do it.

In [security.js](https://github.com/arthurTemporim/hubot-natural/blob/javascript/scripts/lib/security.js) the solution was simple, but in [respond.js](https://github.com/arthurTemporim/hubot-natural/blob/javascript/scripts/actions/respond.js) I need to create a new method, that I called `getResult()` to simplify the code.

I just ran manual tests.
